### PR TITLE
Tie serviceData collection to a job, instead of VM scope, which would…

### DIFF
--- a/app/src/main/java/com/enriqueajin/pomidorki/data/services/CountdownService.kt
+++ b/app/src/main/java/com/enriqueajin/pomidorki/data/services/CountdownService.kt
@@ -37,6 +37,8 @@ import com.enriqueajin.pomidorki.utils.TimeFormatter.formatTime
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -63,31 +65,50 @@ class CountdownService : Service() {
     private val _serviceData = MutableStateFlow(PomodoroServiceData())
     val serviceData = _serviceData.asStateFlow()
 
-    private val coroutineScope = CoroutineScope(Dispatchers.Default)
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
-    fun observeTimeLeft() {
-        coroutineScope.launch {
-            countdownTimer.initialMillis.collect { initialMillis ->
-                updateServiceData(initialMillis = initialMillis)
-            }
-        }
-        coroutineScope.launch {
-            countdownTimer.timeLeft.collect { timeLeft ->
-                if (timeLeft > 0L) {
-                    updateServiceData(timeLeft = timeLeft)
-                    updateNotification(timeLeft)
-                } else if (_serviceData.value.currentState == CountdownState.Started) {
-                    updateServiceData(timeLeft = 0L, currentState = CountdownState.Idle)
-                    notificationManager.cancel(NOTIFICATION_TICK_ID)
-                    stopForeground(STOP_FOREGROUND_REMOVE)
-                    stopSelf()
-                    notifyTimerOver()
+    private var observeTimeLeftJob: Job? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        observeTimeLeft()
+    }
+
+    private fun observeTimeLeft() {
+        if (observeTimeLeftJob != null) return
+
+        observeTimeLeftJob =
+            serviceScope.launch {
+                launch {
+                    countdownTimer.initialMillis.collect { initialMillis ->
+                        updateServiceData(initialMillis = initialMillis)
+                    }
+                }
+                launch {
+                    countdownTimer.timeLeft.collect { timeLeft ->
+                        if (timeLeft > 0L) {
+                            updateServiceData(timeLeft = timeLeft)
+                            updateNotification(timeLeft)
+                        } else if (_serviceData.value.currentState == CountdownState.Started) {
+                            updateServiceData(timeLeft = 0L, currentState = CountdownState.Idle)
+                            notificationManager.cancel(NOTIFICATION_TICK_ID)
+                            stopForeground(STOP_FOREGROUND_REMOVE)
+                            stopSelf()
+                            notifyTimerOver()
+                        }
+                    }
                 }
             }
-        }
     }
 
     override fun onBind(intent: Intent?) = binder
+
+    override fun onDestroy() {
+        observeTimeLeftJob?.cancel()
+        observeTimeLeftJob = null
+        serviceScope.cancel()
+        super.onDestroy()
+    }
 
     override fun onStartCommand(
         intent: Intent?,
@@ -297,11 +318,6 @@ class CountdownService : Service() {
                 .build()
 
         notificationManager.notify(NOTIFICATION_TIMER_RINGTONE_ID, notification)
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        coroutineScope.cancel()
     }
 
     inner class CountdownBinder : Binder() {

--- a/app/src/main/java/com/enriqueajin/pomidorki/presentation/MainActivity.kt
+++ b/app/src/main/java/com/enriqueajin/pomidorki/presentation/MainActivity.kt
@@ -36,7 +36,6 @@ class MainActivity : ComponentActivity() {
                 name: ComponentName?,
                 service: IBinder?,
             ) {
-                println("The service is BOUND!")
                 val binder = service as CountdownService.CountdownBinder
                 val countdownService = binder.getService()
                 viewModel.onServiceConnected(countdownService)
@@ -44,6 +43,7 @@ class MainActivity : ComponentActivity() {
             }
 
             override fun onServiceDisconnected(name: ComponentName?) {
+                viewModel.onServiceDisconnected()
                 isBound = false
             }
         }
@@ -51,8 +51,7 @@ class MainActivity : ComponentActivity() {
     override fun onStart() {
         super.onStart()
         Intent(this, CountdownService::class.java).also {
-            val result = bindService(it, connection, BIND_AUTO_CREATE)
-            println("The result was: $result")
+            bindService(it, connection, BIND_AUTO_CREATE)
         }
     }
 

--- a/app/src/main/java/com/enriqueajin/pomidorki/presentation/home/TimerScreenViewModel.kt
+++ b/app/src/main/java/com/enriqueajin/pomidorki/presentation/home/TimerScreenViewModel.kt
@@ -16,6 +16,7 @@ import com.enriqueajin.pomidorki.utils.Constants.ACTION_SERVICE_RESET
 import com.enriqueajin.pomidorki.utils.PreferencesKeys.SELECTED_TIMER
 import com.enriqueajin.pomidorki.utils.updateState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -38,15 +39,23 @@ class TimerScreenViewModel
         private val _uiEffects = Channel<Effect>()
         val uiEffects = _uiEffects.receiveAsFlow()
 
+        private var serviceDataJob: Job? = null
+
         init {
             checkInitialSelectedTimer()
         }
 
         fun onServiceConnected(service: CountdownService) {
-            service.observeTimeLeft()
-            viewModelScope.launch {
-                service.serviceData.collect(::updateStateServiceData)
-            }
+            serviceDataJob?.cancel()
+            serviceDataJob =
+                viewModelScope.launch {
+                    service.serviceData.collect(::updateStateServiceData)
+                }
+        }
+
+        fun onServiceDisconnected() {
+            serviceDataJob?.cancel()
+            serviceDataJob = null
         }
 
         private fun updateStateServiceData(data: PomodoroServiceData) {


### PR DESCRIPTION
… be wiped after VM's cleared and may create multiple collectors